### PR TITLE
FIX: generating random sparse matrix with size > max(int32)

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -779,9 +779,9 @@ greater than %d - this is not supported on this machine
         ind = np.empty(k, dtype=tp)
         selected = set()
         for i in xrange(k):
-            j = random_state.randint(mn)
+            j = random_state.randint(mn, dtype=tp)
             while j in selected:
-                j = random_state.randint(mn)
+                j = random_state.randint(mn, dtype=tp)
             selected.add(j)
             ind[i] = j
 


### PR DESCRIPTION
This fixes the following bug:
```
from scipy import sparse
N = 46952
x = sparse.random(N,N, density=100/N/N)
```
This occurs because the product of the matrix dimensions is larger than the maximum value of np.int32 and so the the `randint()` call fails. The fix passes the correct type to the `dtype` parameter. The documentation should be updated to mention that the `random_state.randint` function must accept a `dtype` argument.